### PR TITLE
Bug in embed many parameters into route

### DIFF
--- a/libs/routes_helper.php
+++ b/libs/routes_helper.php
@@ -99,9 +99,9 @@ class Helper {
 	public static function getRequestParams($args,$url) {
 		$params = array();
 		/* Get all placeholders for variables in URL */
-		preg_match("/:(\w+)/", $url, $matches);
+		preg_match_all("/:[\w]+/", $url, $matches);
 		/* set values */
-		foreach ($args as $key => $value) { $params[str_replace(":", '' , $matches[$key])] =  $value ; }
+		foreach ($args as $key => $value) { $params[str_replace(":", '' , $matches[0][$key])] =  $value ; }
 		return $params ;
 	}
 


### PR DESCRIPTION
Ao tentar utilizar vários parâmetros na rota, conforme documentação do Slim (http://docs.slimframework.com/#Route-Parameters) era retornado o seguinte erro:

Type: ErrorException
Code: 8
Message: Undefined offset: 2
File: /var/www/project_name/libs/routes_helper.php
Line: 106
